### PR TITLE
allow disabling curly brace escape in code

### DIFF
--- a/lib/mdex_native/comrak.ex
+++ b/lib/mdex_native/comrak.ex
@@ -48,7 +48,7 @@ defmodule MDExNative.Comrak do
   @typedoc "Comrak [`Render`](https://docs.rs/comrak/latest/comrak/options/struct.Render.html) options."
   @type render_options :: keyword()
 
-  @typedoc "Comrak [`Options`](https://docs.rs/comrak/latest/comrak/options/struct.Options.html), plus `:syntax_highlight` and `:sanitize`."
+  @typedoc "Comrak [`Options`](https://docs.rs/comrak/latest/comrak/options/struct.Options.html), plus MDExNative rendering options."
   @type options :: keyword()
 
   @doc ~S"""
@@ -84,8 +84,7 @@ defmodule MDExNative.Comrak do
   ## Options
 
   Pass Comrak options as keyword lists matching [`comrak::Options`](https://docs.rs/comrak/latest/comrak/struct.Options.html)
-  or the extra `:syntax_highlight` and `:sanitize` options:
-  MDExNative adds two top-level options:
+  or the extra MDExNative top-level options:
 
   - `:extension` - mapper to Comrak's [`Extension` options](https://docs.rs/comrak/latest/comrak/options/struct.Extension.html).
   - `:parse` - mapper to Comrak's [`Parse` options](https://docs.rs/comrak/latest/comrak/options/struct.Parse.html).
@@ -118,6 +117,9 @@ defmodule MDExNative.Comrak do
 
     See the [Sanitization](sanitization.md) guide for more info.
 
+  - `:escape_curly_braces_in_code` - escapes `{` and `}` inside `<code>` tags after
+    rendering. Defaults to `true`.
+
   ## Examples
 
       iex> MDExNative.Comrak.markdown_to_html("**bold**")
@@ -133,6 +135,10 @@ defmodule MDExNative.Comrak do
       iex> markdown = "```rust\nfn main() {}\n```"
       iex> MDExNative.Comrak.markdown_to_html(markdown)
       "<pre><code class=\"language-rust\">fn main() &lbrace;&rbrace;\n</code></pre>\n"
+
+      iex> markdown = "```rust\nfn main() {}\n```"
+      iex> MDExNative.Comrak.markdown_to_html(markdown, escape_curly_braces_in_code: false)
+      "<pre><code class=\"language-rust\">fn main() {}\n</code></pre>\n"
 
   """
   @spec markdown_to_html(markdown(), options()) :: html()

--- a/native/mdex_native_nif/src/lib.rs
+++ b/native/mdex_native_nif/src/lib.rs
@@ -185,6 +185,7 @@ fn markdown_to_html_with_options<'a>(
     md: &str,
     options: ExOptions,
 ) -> NifResult<Term<'a>> {
+    let escape_curly_braces_in_code = options.escape_curly_braces_in_code.unwrap_or(true);
     let (comrak_options, lumis_adapter, sanitize) = render_parts(options)?;
     let arena = Arena::new();
     let root = comrak::parse_document(&arena, md, &comrak_options);
@@ -193,7 +194,7 @@ fn markdown_to_html_with_options<'a>(
 
     format_html_with_plugins(root, &comrak_options, &mut buffer, &plugins)
         .expect("writing to String is infallible");
-    Ok(do_safe_html(buffer, &sanitize, false, true).encode(env))
+    Ok(do_safe_html(buffer, &sanitize, false, escape_curly_braces_in_code).encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -261,6 +262,7 @@ fn document_to_html_with_options<'a>(
     ex_document: Term<'a>,
     options: ExOptions,
 ) -> NifResult<Term<'a>> {
+    let escape_curly_braces_in_code = options.escape_curly_braces_in_code.unwrap_or(true);
     let arena = Arena::new();
     let comrak_ast = document_term_to_comrak_ast(&arena, ex_document)?;
     let (comrak_options, lumis_adapter, sanitize) = render_parts(options)?;
@@ -269,7 +271,7 @@ fn document_to_html_with_options<'a>(
 
     format_html_with_plugins(comrak_ast, &comrak_options, &mut buffer, &plugins)
         .expect("writing to String is infallible");
-    Ok(do_safe_html(buffer, &sanitize, false, true).encode(env))
+    Ok(do_safe_html(buffer, &sanitize, false, escape_curly_braces_in_code).encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/mdex_native_nif/src/types/options.rs
+++ b/native/mdex_native_nif/src/types/options.rs
@@ -407,6 +407,7 @@ pub struct ExOptions {
     pub render: Option<ExRenderOptions>,
     pub syntax_highlight: Option<ExSyntaxHighlightOptions>,
     pub sanitize: Option<ExSanitizeOption>,
+    pub escape_curly_braces_in_code: Option<bool>,
 }
 
 impl<'a> Decoder<'a> for ExOptions {
@@ -417,6 +418,7 @@ impl<'a> Decoder<'a> for ExOptions {
             render: optional_field(term, "render")?,
             syntax_highlight: syntax_highlight_field(term)?,
             sanitize: optional_field(term, "sanitize")?,
+            escape_curly_braces_in_code: optional_field(term, "escape_curly_braces_in_code")?,
         })
     }
 }

--- a/test/mdex_native/comrak_test.exs
+++ b/test/mdex_native/comrak_test.exs
@@ -50,6 +50,36 @@ defmodule MDExNative.ComrakTest do
     assert MDExNative.Comrak.markdown_to_xml("# Hello") =~ ~s(<heading level="1">)
   end
 
+  test "escapes curly braces in code by default" do
+    markdown = """
+    Inline `%{}`.
+
+    ```elixir
+    %{}
+    ```
+    """
+
+    assert MDExNative.Comrak.markdown_to_html(markdown) ==
+             "<p>Inline <code>%&lbrace;&rbrace;</code>.</p>\n" <>
+               "<pre><code class=\"language-elixir\">%&lbrace;&rbrace;\n</code></pre>\n"
+  end
+
+  test "can preserve curly braces in code" do
+    markdown = """
+    Inline `%{}`.
+
+    ```elixir
+    %{}
+    ```
+    """
+
+    assert MDExNative.Comrak.markdown_to_html(markdown,
+             escape_curly_braces_in_code: false
+           ) ==
+             "<p>Inline <code>%{}</code>.</p>\n" <>
+               "<pre><code class=\"language-elixir\">%{}\n</code></pre>\n"
+  end
+
   test "renders parsed documents" do
     document = MDExNative.Comrak.parse_document("# Hello")
 
@@ -503,6 +533,24 @@ defmodule MDExNative.ComrakTest do
 
     assert MDExNative.Comrak.document_to_html(document, render: [unsafe: true], sanitize: nil) ==
              "<p>|spoiler|</p>\n"
+  end
+
+  test "document_to_html can preserve curly braces in code" do
+    document = %Document{
+      nodes: [
+        %MDExNative.Comrak.CodeBlock{
+          info: "elixir",
+          literal: "%{}\n"
+        }
+      ]
+    }
+
+    assert MDExNative.Comrak.document_to_html(document) ==
+             "<pre><code class=\"language-elixir\">%&lbrace;&rbrace;\n</code></pre>\n"
+
+    assert MDExNative.Comrak.document_to_html(document,
+             escape_curly_braces_in_code: false
+           ) == "<pre><code class=\"language-elixir\">%{}\n</code></pre>\n"
   end
 
   test "parses code fence info with language only" do


### PR DESCRIPTION
I'm working on moving the Phoenix website from custom code + Earmark to NimblePublisher.

While NimblePublisher 2.0 moved to mdex_native, the way it highlights code currently breaks curly braces:

<img width="831" height="750" alt="image" src="https://github.com/user-attachments/assets/e568d03b-9b54-4097-9008-6e0b0184512c" />

I traced this to mdex_native always forcing curly braces to be escaped (why?), so this PR adds an option to disable this.