### PR TITLE
fix: preserve curly braces

### DIFF
--- a/examples/cloudflare_source.exs
+++ b/examples/cloudflare_source.exs
@@ -4,7 +4,11 @@ File.rm_rf!(cache_path)
 System.delete_env("MDEX_NATIVE_BUILD")
 
 System.put_env("MIX_INSTALL_DIR", Path.join(cache_path, "mix_install"))
-System.put_env("RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH", Path.join(cache_path, "rustler_precompiled"))
+
+System.put_env(
+  "RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH",
+  Path.join(cache_path, "rustler_precompiled")
+)
 
 Mix.install(
   [{:mdex_native, ">= 0.2.3"}],

--- a/integration_test/fixtures/dummy_app/test/config_test.exs
+++ b/integration_test/fixtures/dummy_app/test/config_test.exs
@@ -6,7 +6,7 @@ defmodule MDExNativeE2E.ConfigTest do
     case System.fetch_env!("MDEX_NATIVE_E2E_CASE") do
       e2e_case when e2e_case in ["default", "cloudflare"] ->
         assert MDExNative.Comrak.markdown_to_html(@rust, syntax_highlight: nil) ==
-                 "<pre><code class=\"language-rust\">fn main() &lbrace;&rbrace;\n</code></pre>\n"
+                 "<pre><code class=\"language-rust\">fn main() {}\n</code></pre>\n"
 
         lumis_error =
           assert_raise RuntimeError, fn ->
@@ -26,7 +26,7 @@ defmodule MDExNativeE2E.ConfigTest do
 
       "lumis" ->
         assert lumis_html(@rust) ==
-                 "<pre class=\"lumis\" style=\"color: #cad3f5; background-color: #24273a;\"><code class=\"language-rust\" translate=\"no\" tabindex=\"0\"><div class=\"l-line\" data-line=\"1\"><span style=\"color: #c6a0f6;\">fn</span> <span style=\"color: #8aadf4;\">main</span><span style=\"color: #939ab7;\">(</span><span style=\"color: #939ab7;\">)</span> <span style=\"color: #939ab7;\">&lbrace;</span><span style=\"color: #939ab7;\">&rbrace;</span>\n</div></code></pre>\n"
+                 "<pre class=\"lumis\" style=\"color: #cad3f6; background-color: #24273b;\"><code class=\"language-rust\" translate=\"no\" tabindex=\"0\"><div class=\"l-line\" data-line=\"1\"><span style=\"color: #c6a0f7;\">fn</span> <span style=\"color: #8aadf5;\">main</span><span style=\"color: #939ab8;\">(</span><span style=\"color: #939ab8;\">)</span> <span style=\"color: #939ab8;\">{</span><span style=\"color: #939ab8;\">}</span>\n</div></code></pre>\n"
 
         error =
           assert_raise RuntimeError, fn ->
@@ -38,7 +38,7 @@ defmodule MDExNativeE2E.ConfigTest do
 
       "syntect" ->
         assert syntect_html(@rust) ==
-                 "<pre class=\"syntax-highlighting\"><code class=\"language-rust\"><span class=\"source rust\"><span class=\"meta function rust\"><span class=\"meta function rust\"><span class=\"storage type function rust\">fn</span> </span><span class=\"entity name function rust\">main</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters begin rust\">(</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters end rust\">)</span></span></span></span><span class=\"meta function rust\"> </span><span class=\"meta function rust\"><span class=\"meta block rust\"><span class=\"punctuation section block begin rust\">&lbrace;</span></span><span class=\"meta block rust\"><span class=\"punctuation section block end rust\">&rbrace;</span></span></span>\n</span></code></pre>\n"
+                 "<pre class=\"syntax-highlighting\"><code class=\"language-rust\"><span class=\"source rust\"><span class=\"meta function rust\"><span class=\"meta function rust\"><span class=\"storage type function rust\">fn</span> </span><span class=\"entity name function rust\">main</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters begin rust\">(</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters end rust\">)</span></span></span></span><span class=\"meta function rust\"> </span><span class=\"meta function rust\"><span class=\"meta block rust\"><span class=\"punctuation section block begin rust\">{</span></span><span class=\"meta block rust\"><span class=\"punctuation section block end rust\">}</span></span></span>\n</span></code></pre>\n"
 
         error =
           assert_raise RuntimeError, fn ->

--- a/lib/mdex_native/comrak.ex
+++ b/lib/mdex_native/comrak.ex
@@ -132,7 +132,7 @@ defmodule MDExNative.Comrak do
       # default disabled syntax highlighter
       iex> markdown = "```rust\nfn main() {}\n```"
       iex> MDExNative.Comrak.markdown_to_html(markdown)
-      "<pre><code class=\"language-rust\">fn main() &lbrace;&rbrace;\n</code></pre>\n"
+      "<pre><code class=\"language-rust\">fn main() {}\n</code></pre>\n"
 
   """
   @spec markdown_to_html(markdown(), options()) :: html()

--- a/native/mdex_native_nif/Cargo.lock
+++ b/native/mdex_native_nif/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "lumis"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9147d5237cf75de737d20858a159c323a00bd2a1891ae6791c7224de3cd2bb95"
+checksum = "9ef2e6a5ce8ce17bccccdcbdbba3bf544ba55d98f7899723206604611455df7f"
 dependencies = [
  "anyhow",
  "cc",
@@ -805,9 +805,9 @@ checksum = "b53f577698ec4ecb8d23b052ce0a6701ae4fc8cd315417bb77ec045c01f00caa"
 
 [[package]]
 name = "lumis-core"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3a07402769c248e89740f1497685ea399ce820406251e342766da3066888f0"
+checksum = "fbda3f6195577ab8e59d8c1f6506610ac817e01382f110666ab86db9f779fe4e"
 dependencies = [
  "derive_builder",
  "glob",

--- a/native/mdex_native_nif/Cargo.toml
+++ b/native/mdex_native_nif/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 ammonia = "4.1"
 comrak = { version = "0.52", default-features = false, features = ["shortcodes", "phoenix_heex"] }
-lumis = { version = "0.10", default-features = false, optional = true }
+lumis = { version = "0.11", default-features = false, optional = true }
 lol_html = "3.0"
 parking_lot = "0.12"
 phf = { version = "0.13", features = ["macros"] }

--- a/native/mdex_native_nif/src/lib.rs
+++ b/native/mdex_native_nif/src/lib.rs
@@ -186,6 +186,7 @@ fn markdown_to_html_with_options<'a>(
     options: ExOptions,
 ) -> NifResult<Term<'a>> {
     let (comrak_options, lumis_adapter, sanitize) = render_parts(options)?;
+    let escape_curly_braces_in_code = comrak_options.extension.phoenix_heex;
     let arena = Arena::new();
     let root = comrak::parse_document(&arena, md, &comrak_options);
     let mut buffer = String::new();
@@ -193,7 +194,7 @@ fn markdown_to_html_with_options<'a>(
 
     format_html_with_plugins(root, &comrak_options, &mut buffer, &plugins)
         .expect("writing to String is infallible");
-    Ok(do_safe_html(buffer, &sanitize, false, true).encode(env))
+    Ok(do_safe_html(buffer, &sanitize, false, escape_curly_braces_in_code).encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -264,12 +265,13 @@ fn document_to_html_with_options<'a>(
     let arena = Arena::new();
     let comrak_ast = document_term_to_comrak_ast(&arena, ex_document)?;
     let (comrak_options, lumis_adapter, sanitize) = render_parts(options)?;
+    let escape_curly_braces_in_code = comrak_options.extension.phoenix_heex;
     let mut buffer = String::new();
     let plugins = plugins(&lumis_adapter);
 
     format_html_with_plugins(comrak_ast, &comrak_options, &mut buffer, &plugins)
         .expect("writing to String is infallible");
-    Ok(do_safe_html(buffer, &sanitize, false, true).encode(env))
+    Ok(do_safe_html(buffer, &sanitize, false, escape_curly_braces_in_code).encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/mdex_native_nif/src/lumis_adapter.rs
+++ b/native/mdex_native_nif/src/lumis_adapter.rs
@@ -600,9 +600,9 @@ fn main() {
 
         let output = run_test(markdown, ExFormatterOption::default(), Options::default());
 
-        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1">fn main() &lbrace;
+        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1">fn main() {
 </div><div class="l-line" data-line="2">    let message = &quot;Hello, world!&quot;;
-</div><div class="l-line" data-line="3">&rbrace;
+</div><div class="l-line" data-line="3">}
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -656,9 +656,9 @@ fn main() {
 
         let output = run_test(markdown, formatter, Options::default());
 
-        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1">fn main() &lbrace;
+        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1">fn main() {
 </div><div class="l-line" data-line="2">    let message = &quot;Hello, world!&quot;;
-</div><div class="l-line" data-line="3">&rbrace;
+</div><div class="l-line" data-line="3">}
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -687,11 +687,11 @@ fn main() {
 
         let output = run_test(markdown, formatter, Options::default());
 
-        let expected = r#"<pre class="lumis custom-pre-class" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span data-highlight="keyword.function" style="color: #88c0d0; font-style: italic;">fn</span> <span data-highlight="function" style="color: #88c0d0; font-style: italic;">main</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">(</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">)</span> <span data-highlight="punctuation.bracket" style="color: #88c0d0;">&lbrace;</span>
+        let expected = r#"<pre class="lumis custom-pre-class" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span data-highlight="keyword.function" style="color: #88c0d0; font-style: italic;">fn</span> <span data-highlight="function" style="color: #88c0d0; font-style: italic;">main</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">(</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">)</span> <span data-highlight="punctuation.bracket" style="color: #88c0d0;">{</span>
 </div><div class="l-line" data-line="2">    <span data-highlight="keyword" style="color: #81a1c1; font-style: italic;">let</span> <span data-highlight="variable" style="color: #d8dee9; font-weight: bold;">a</span> <span data-highlight="operator" style="color: #81a1c1;">=</span> <span data-highlight="number" style="color: #b48ead;">1</span><span data-highlight="punctuation.delimiter" style="color: #88c0d0;">;</span>
 </div><div class="l-line" data-line="3">    <span data-highlight="keyword" style="color: #81a1c1; font-style: italic;">let</span> <span data-highlight="variable" style="color: #d8dee9; font-weight: bold;">b</span> <span data-highlight="operator" style="color: #81a1c1;">=</span> <span data-highlight="number" style="color: #b48ead;">2</span><span data-highlight="punctuation.delimiter" style="color: #88c0d0;">;</span>
 </div><div class="l-line" data-line="4">    <span data-highlight="keyword" style="color: #81a1c1; font-style: italic;">let</span> <span data-highlight="variable" style="color: #d8dee9; font-weight: bold;">sum</span> <span data-highlight="operator" style="color: #81a1c1;">=</span> <span data-highlight="variable" style="color: #d8dee9; font-weight: bold;">a</span> <span data-highlight="operator" style="color: #81a1c1;">+</span> <span data-highlight="variable" style="color: #d8dee9; font-weight: bold;">b</span><span data-highlight="punctuation.delimiter" style="color: #88c0d0;">;</span>
-</div><div class="l-line" data-line="5"><span data-highlight="punctuation.bracket" style="color: #88c0d0;">&rbrace;</span>
+</div><div class="l-line" data-line="5"><span data-highlight="punctuation.bracket" style="color: #88c0d0;">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -725,12 +725,12 @@ fn main() {
 
         let output = run_test(markdown, formatter, options);
 
-        let expected = r#"<pre class="lumis my-custom-pre extra-class" style="color: #1f2328; background-color: #ffffff;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line custom-highlight-class" style="background-color: #ffffcc; border-left: 3px solid #ff0000" data-line="1"><span data-highlight="keyword.function" style="color: #cf222e;">fn</span> <span data-highlight="function" style="color: #6639ba;">main</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">(</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">)</span> <span data-highlight="punctuation.bracket" style="color: #1f2328;">&lbrace;</span>
+        let expected = r#"<pre class="lumis my-custom-pre extra-class" style="color: #1f2328; background-color: #ffffff;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line custom-highlight-class" style="background-color: #ffffcc; border-left: 3px solid #ff0000" data-line="1"><span data-highlight="keyword.function" style="color: #cf222e;">fn</span> <span data-highlight="function" style="color: #6639ba;">main</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">(</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">)</span> <span data-highlight="punctuation.bracket" style="color: #1f2328;">{</span>
 </div><div class="l-line" data-line="2">    <span data-highlight="keyword" style="color: #cf222e;">let</span> <span data-highlight="variable" style="color: #1f2328;">x</span> <span data-highlight="operator" style="color: #0550ae;">=</span> <span data-highlight="number" style="color: #0550ae;">1</span><span data-highlight="punctuation.delimiter" style="color: #1f2328;">;</span>
 </div><div class="l-line custom-highlight-class" style="background-color: #ffffcc; border-left: 3px solid #ff0000" data-line="3">    <span data-highlight="keyword" style="color: #cf222e;">let</span> <span data-highlight="variable" style="color: #1f2328;">y</span> <span data-highlight="operator" style="color: #0550ae;">=</span> <span data-highlight="number" style="color: #0550ae;">2</span><span data-highlight="punctuation.delimiter" style="color: #1f2328;">;</span>
 </div><div class="l-line custom-highlight-class" style="background-color: #ffffcc; border-left: 3px solid #ff0000" data-line="4">    <span data-highlight="keyword" style="color: #cf222e;">let</span> <span data-highlight="variable" style="color: #1f2328;">z</span> <span data-highlight="operator" style="color: #0550ae;">=</span> <span data-highlight="number" style="color: #0550ae;">3</span><span data-highlight="punctuation.delimiter" style="color: #1f2328;">;</span>
 </div><div class="l-line custom-highlight-class" style="background-color: #ffffcc; border-left: 3px solid #ff0000" data-line="5">    <span data-highlight="keyword" style="color: #cf222e;">let</span> <span data-highlight="variable" style="color: #1f2328;">message</span> <span data-highlight="operator" style="color: #0550ae;">=</span> <span data-highlight="string" style="color: #0a3069;">&quot;Hello, world!&quot;</span><span data-highlight="punctuation.delimiter" style="color: #1f2328;">;</span>
-</div><div class="l-line" data-line="6"><span data-highlight="punctuation.bracket" style="color: #1f2328;">&rbrace;</span>
+</div><div class="l-line" data-line="6"><span data-highlight="punctuation.bracket" style="color: #1f2328;">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -1069,10 +1069,10 @@ fn main() {
 
         let output = run_test(markdown, formatter, options);
 
-        let expected = r#"<pre class="lumis default-class" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" style="background-color: #e7eaf0;" data-line="1"><span data-highlight="keyword.function" style="color: #cf222e;">fn</span> <span data-highlight="function" style="color: #6639ba;">main</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">(</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">)</span> <span data-highlight="punctuation.bracket" style="color: #1f2328;">&lbrace;</span>
+        let expected = r#"<pre class="lumis default-class" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" style="background-color: #e7eaf0;" data-line="1"><span data-highlight="keyword.function" style="color: #cf222e;">fn</span> <span data-highlight="function" style="color: #6639ba;">main</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">(</span><span data-highlight="punctuation.bracket" style="color: #1f2328;">)</span> <span data-highlight="punctuation.bracket" style="color: #1f2328;">{</span>
 </div><div class="l-line" data-line="2">    <span data-highlight="keyword" style="color: #cf222e;">let</span> <span data-highlight="variable" style="color: #1f2328;">x</span> <span data-highlight="operator" style="color: #0550ae;">=</span> <span data-highlight="number" style="color: #0550ae;">1</span><span data-highlight="punctuation.delimiter" style="color: #1f2328;">;</span>
 </div><div class="l-line" style="background-color: #e7eaf0;" data-line="3">    <span data-highlight="keyword" style="color: #cf222e;">let</span> <span data-highlight="variable" style="color: #1f2328;">message</span> <span data-highlight="operator" style="color: #0550ae;">=</span> <span data-highlight="string" style="color: #0a3069;">&quot;Hello, world!&quot;</span><span data-highlight="punctuation.delimiter" style="color: #1f2328;">;</span>
-</div><div class="l-line" data-line="4"><span data-highlight="punctuation.bracket" style="color: #1f2328;">&rbrace;</span>
+</div><div class="l-line" data-line="4"><span data-highlight="punctuation.bracket" style="color: #1f2328;">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -1096,9 +1096,9 @@ fn main() {
 
         let output = run_test(markdown, formatter, Options::default());
 
-        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span class="l-keyword-function">fn</span> <span class="l-function">main</span><span class="l-punctuation-bracket">(</span><span class="l-punctuation-bracket">)</span> <span class="l-punctuation-bracket">&lbrace;</span>
+        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span class="l-keyword-function">fn</span> <span class="l-function">main</span><span class="l-punctuation-bracket">(</span><span class="l-punctuation-bracket">)</span> <span class="l-punctuation-bracket">{</span>
 </div><div class="l-line" data-line="2">    <span class="l-keyword">let</span> <span class="l-variable">message</span> <span class="l-operator">=</span> <span class="l-string">&quot;Hello, world!&quot;</span><span class="l-punctuation-delimiter">;</span>
-</div><div class="l-line" data-line="3"><span class="l-punctuation-bracket">&rbrace;</span>
+</div><div class="l-line" data-line="3"><span class="l-punctuation-bracket">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -1148,11 +1148,11 @@ fn main() {
 
         let output = run_test(markdown, formatter, Options::default());
 
-        let expected = r#"<pre class="lumis custom-linked-class"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span class="l-keyword-function">fn</span> <span class="l-function">main</span><span class="l-punctuation-bracket">(</span><span class="l-punctuation-bracket">)</span> <span class="l-punctuation-bracket">&lbrace;</span>
+        let expected = r#"<pre class="lumis custom-linked-class"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span class="l-keyword-function">fn</span> <span class="l-function">main</span><span class="l-punctuation-bracket">(</span><span class="l-punctuation-bracket">)</span> <span class="l-punctuation-bracket">{</span>
 </div><div class="l-line" data-line="2">    <span class="l-keyword">let</span> <span class="l-variable">a</span> <span class="l-operator">=</span> <span class="l-number">1</span><span class="l-punctuation-delimiter">;</span>
 </div><div class="l-line" data-line="3">    <span class="l-keyword">let</span> <span class="l-variable">b</span> <span class="l-operator">=</span> <span class="l-number">2</span><span class="l-punctuation-delimiter">;</span>
 </div><div class="l-line" data-line="4">    <span class="l-keyword">let</span> <span class="l-variable">sum</span> <span class="l-operator">=</span> <span class="l-variable">a</span> <span class="l-operator">+</span> <span class="l-variable">b</span><span class="l-punctuation-delimiter">;</span>
-</div><div class="l-line" data-line="5"><span class="l-punctuation-bracket">&rbrace;</span>
+</div><div class="l-line" data-line="5"><span class="l-punctuation-bracket">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -1183,12 +1183,12 @@ fn main() {
 
         let output = run_test(markdown, formatter, options);
 
-        let expected = r#"<pre class="lumis custom-linked-pre extra-linked"><code class="language-rust" translate="no" tabindex="0"><div class="l-line my-custom-highlight-line" data-line="1"><span class="l-keyword-function">fn</span> <span class="l-function">main</span><span class="l-punctuation-bracket">(</span><span class="l-punctuation-bracket">)</span> <span class="l-punctuation-bracket">&lbrace;</span>
+        let expected = r#"<pre class="lumis custom-linked-pre extra-linked"><code class="language-rust" translate="no" tabindex="0"><div class="l-line my-custom-highlight-line" data-line="1"><span class="l-keyword-function">fn</span> <span class="l-function">main</span><span class="l-punctuation-bracket">(</span><span class="l-punctuation-bracket">)</span> <span class="l-punctuation-bracket">{</span>
 </div><div class="l-line my-custom-highlight-line" data-line="2">    <span class="l-keyword">let</span> <span class="l-variable">x</span> <span class="l-operator">=</span> <span class="l-number">1</span><span class="l-punctuation-delimiter">;</span>
 </div><div class="l-line" data-line="3">    <span class="l-keyword">let</span> <span class="l-variable">y</span> <span class="l-operator">=</span> <span class="l-number">2</span><span class="l-punctuation-delimiter">;</span>
 </div><div class="l-line my-custom-highlight-line" data-line="4">    <span class="l-keyword">let</span> <span class="l-variable">z</span> <span class="l-operator">=</span> <span class="l-number">3</span><span class="l-punctuation-delimiter">;</span>
 </div><div class="l-line my-custom-highlight-line" data-line="5">    <span class="l-keyword">let</span> <span class="l-variable">message</span> <span class="l-operator">=</span> <span class="l-string">&quot;Hello, world!&quot;</span><span class="l-punctuation-delimiter">;</span>
-</div><div class="l-line" data-line="6"><span class="l-punctuation-bracket">&rbrace;</span>
+</div><div class="l-line" data-line="6"><span class="l-punctuation-bracket">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -1219,9 +1219,9 @@ fn main() {
 
         let output = run_test(markdown, formatter, options);
 
-        let expected = r#"<pre class="lumis" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span data-highlight="keyword.function" style="color: #88c0d0;">fn</span> <span data-highlight="function" style="color: #88c0d0;">main</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">(</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">)</span> <span data-highlight="punctuation.bracket" style="color: #88c0d0;">&lbrace;</span>
+        let expected = r#"<pre class="lumis" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span data-highlight="keyword.function" style="color: #88c0d0;">fn</span> <span data-highlight="function" style="color: #88c0d0;">main</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">(</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">)</span> <span data-highlight="punctuation.bracket" style="color: #88c0d0;">{</span>
 </div><div class="l-line" data-line="2">    <span data-highlight="keyword" style="color: #81a1c1;">let</span> <span data-highlight="variable" style="color: #d8dee9; font-weight: bold;">message</span> <span data-highlight="operator" style="color: #81a1c1;">=</span> <span data-highlight="string" style="color: #a3be8c;">&quot;Hello, world!&quot;</span><span data-highlight="punctuation.delimiter" style="color: #88c0d0;">;</span>
-</div><div class="l-line" data-line="3"><span data-highlight="punctuation.bracket" style="color: #88c0d0;">&rbrace;</span>
+</div><div class="l-line" data-line="3"><span data-highlight="punctuation.bracket" style="color: #88c0d0;">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());
@@ -1252,9 +1252,9 @@ fn main() {
 
         let output = run_test(markdown, formatter, options);
 
-        let expected = r#"<pre class="lumis" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span data-highlight="keyword.function" style="color: #88c0d0;">fn</span> <span data-highlight="function" style="color: #88c0d0;">main</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">(</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">)</span> <span data-highlight="punctuation.bracket" style="color: #88c0d0;">&lbrace;</span>
+        let expected = r#"<pre class="lumis" style="color: #d8dee9; background-color: #2e3440;"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span data-highlight="keyword.function" style="color: #88c0d0;">fn</span> <span data-highlight="function" style="color: #88c0d0;">main</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">(</span><span data-highlight="punctuation.bracket" style="color: #88c0d0;">)</span> <span data-highlight="punctuation.bracket" style="color: #88c0d0;">{</span>
 </div><div class="l-line" data-line="2">    <span data-highlight="keyword" style="color: #81a1c1;">let</span> <span data-highlight="variable" style="color: #d8dee9; font-weight: bold;">message</span> <span data-highlight="operator" style="color: #81a1c1;">=</span> <span data-highlight="string" style="color: #a3be8c;">&quot;Hello, world!&quot;</span><span data-highlight="punctuation.delimiter" style="color: #88c0d0;">;</span>
-</div><div class="l-line" data-line="3"><span data-highlight="punctuation.bracket" style="color: #88c0d0;">&rbrace;</span>
+</div><div class="l-line" data-line="3"><span data-highlight="punctuation.bracket" style="color: #88c0d0;">}</span>
 </div></code></pre>"#;
 
         assert_str_eq!(output.trim(), expected.trim());

--- a/test/mdex_native/comrak_test.exs
+++ b/test/mdex_native/comrak_test.exs
@@ -50,12 +50,57 @@ defmodule MDExNative.ComrakTest do
     assert MDExNative.Comrak.markdown_to_xml("# Hello") =~ ~s(<heading level="1">)
   end
 
+  test "preserves curly braces in code by default" do
+    markdown = """
+    Inline `%{}`.
+
+    ```elixir
+    %{}
+    ```
+    """
+
+    assert MDExNative.Comrak.markdown_to_html(markdown) ==
+             "<p>Inline <code>%{}</code>.</p>\n" <>
+               "<pre><code class=\"language-elixir\">%{}\n</code></pre>\n"
+  end
+
+  test "escapes curly braces in code when phoenix_heex is enabled" do
+    markdown = """
+    Inline `%{}`.
+
+    ```elixir
+    %{}
+    ```
+    """
+
+    assert MDExNative.Comrak.markdown_to_html(markdown, extension: [phoenix_heex: true]) ==
+             "<p>Inline <code>%&lbrace;&rbrace;</code>.</p>\n" <>
+               "<pre><code class=\"language-elixir\">%&lbrace;&rbrace;\n</code></pre>\n"
+  end
+
   test "renders parsed documents" do
     document = MDExNative.Comrak.parse_document("# Hello")
 
     assert MDExNative.Comrak.document_to_html(document) == "<h1>Hello</h1>\n"
     assert MDExNative.Comrak.document_to_xml(document) =~ ~s(<heading level="1">)
     assert MDExNative.Comrak.document_to_commonmark(document) == "# Hello\n"
+  end
+
+  test "document_to_html escapes curly braces in code only when phoenix_heex is enabled" do
+    document = %Document{
+      nodes: [
+        %MDExNative.Comrak.CodeBlock{
+          info: "elixir",
+          literal: "%{}\n"
+        }
+      ]
+    }
+
+    assert MDExNative.Comrak.document_to_html(document) ==
+             "<pre><code class=\"language-elixir\">%{}\n</code></pre>\n"
+
+    assert MDExNative.Comrak.document_to_html(document, extension: [phoenix_heex: true]) ==
+             "<pre><code class=\"language-elixir\">%&lbrace;&rbrace;\n</code></pre>\n"
   end
 
   test "parses a mixed markdown document and renders it from the document AST" do


### PR DESCRIPTION
Preserve curly braces by default and only escape when phoenix_heex integration is enabled to avoid the HEEx engine parsing it as Elixir code.

Close #31