### PR TITLE
chore: release v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.8](https://github.com/leandrocp/mdex_native/compare/v0.2.7...v0.2.8) (2026-08-13)
+
+### Features
+
+- Update lumis v0.13 by @leandrocp in [#53](https://github.com/leandrocp/mdex_native/pull/53)
+
 ## 0.2.7 (2026-08-03)
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule MDExNative.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/leandrocp/mdex_native"
-  @version "0.2.7"
+  @version "0.2.8"
   @force_build? System.get_env("MDEX_NATIVE_BUILD") in ["1", "true"]
 
   def project do


### PR DESCRIPTION
Automated Elixir release pull request.

- Bumps the package version to `0.2.8`.
- Updates `CHANGELOG.md` with categorized, contributor-attributed release notes generated by git-cliff.
- Merging this pull request creates tag `v0.2.8` and its GitHub Release.