### PR TITLE
feat: add parser metadata for streaming

### DIFF
--- a/lib/mdex_native/native.ex
+++ b/lib/mdex_native/native.ex
@@ -108,6 +108,7 @@ defmodule MDExNative.Native do
     force_build: force_build
 
   def parse_document(_md, _opts), do: :erlang.nif_error(:nif_not_loaded)
+  def parse_document_with_metadata(_md, _opts), do: :erlang.nif_error(:nif_not_loaded)
   def markdown_to_html_with_options(_md, _opts), do: :erlang.nif_error(:nif_not_loaded)
   def markdown_to_xml_with_options(_md, _opts), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/native/mdex_native_nif/src/lib.rs
+++ b/native/mdex_native_nif/src/lib.rs
@@ -234,19 +234,18 @@ fn first_reference_link_block_start<'a>(
         }
     }
 
-    let mut block_starts = root
+    let mut block_spans = root
         .children()
-        .map(|node| node.data().sourcepos.start.line)
+        .map(|node| {
+            let sourcepos = node.data().sourcepos;
+            (sourcepos.start.line, sourcepos.end.line)
+        })
         .collect::<Vec<_>>();
-    block_starts.dedup();
+    block_spans.dedup();
 
-    for (index, start_line) in block_starts.iter().copied().enumerate() {
+    for (start_line, end_line) in block_spans {
         let from = *line_starts.get(start_line.saturating_sub(1))?;
-        let to = block_starts
-            .get(index + 1)
-            .and_then(|line| line_starts.get(line.saturating_sub(1)))
-            .copied()
-            .unwrap_or(md.len());
+        let to = line_starts.get(end_line).copied().unwrap_or(md.len());
 
         if markdown_has_unresolved_reference_link(&md[from..to], options) {
             return Some(start_line);

--- a/native/mdex_native_nif/src/lib.rs
+++ b/native/mdex_native_nif/src/lib.rs
@@ -7,7 +7,7 @@ mod types;
 
 use comrak::adapters::SyntaxHighlighterAdapter;
 use comrak::format_html_with_plugins;
-use comrak::nodes::AstNode;
+use comrak::nodes::{AstNode, NodeValue};
 use comrak::options::Plugins;
 #[cfg(feature = "syntect")]
 use comrak::plugins::syntect::{SyntectAdapter, SyntectAdapterBuilder};
@@ -18,6 +18,8 @@ use lol_html::{rewrite_str, text, RewriteStrSettings};
 use lumis_adapter::LumisAdapter;
 use rustler::types::list::ListIterator;
 use rustler::{Encoder, Env, NifResult, Term};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use types::{document::*, options::*};
 
 rustler::init!("Elixir.MDExNative.Native");
@@ -177,6 +179,103 @@ fn parse_document<'a>(env: Env<'a>, md: &str, options: ExOptions) -> NifResult<T
     let arena = Arena::new();
     let root = comrak::parse_document(&arena, md, &comrak_options);
     comrak_ast_to_document_term(env, root)
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn parse_document_with_metadata<'a>(
+    env: Env<'a>,
+    md: &str,
+    options: ExOptions,
+) -> NifResult<Term<'a>> {
+    let base_options = options.comrak_options();
+    let mut comrak_options = base_options.clone();
+    let unresolved_reference_links = Arc::new(AtomicUsize::new(0));
+    let callback_count = Arc::clone(&unresolved_reference_links);
+
+    comrak_options.parse.broken_link_callback = Some(Arc::new(
+        move |_reference: comrak::options::BrokenLinkReference<'_>| {
+            callback_count.fetch_add(1, Ordering::Relaxed);
+            None
+        },
+    ));
+
+    let arena = Arena::new();
+    let root = comrak::parse_document(&arena, md, &comrak_options);
+    let task_items = root
+        .descendants()
+        .filter(|node| matches!(&node.data().value, NodeValue::TaskItem(_)))
+        .count();
+    let reference_link_block_start = first_reference_link_block_start(md, root, &base_options);
+    let document = comrak_ast_to_document_term(env, root)?;
+    // Comrak runs the broken-link callback for `[x]` before its task-list
+    // postprocessor promotes that syntax to a TaskItem. Those parser-owned
+    // nodes are not unresolved links and must not leak into the metadata.
+    let unresolved_reference_link = unresolved_reference_links.load(Ordering::Relaxed) > task_items;
+
+    Ok((
+        document,
+        unresolved_reference_link,
+        reference_link_block_start,
+    )
+        .encode(env))
+}
+
+fn first_reference_link_block_start<'a>(
+    md: &str,
+    root: &'a AstNode<'a>,
+    options: &Options<'static>,
+) -> Option<usize> {
+    let mut line_starts = Vec::with_capacity(md.lines().count().saturating_add(1));
+    line_starts.push(0);
+
+    for (offset, byte) in md.bytes().enumerate() {
+        if byte == b'\n' {
+            line_starts.push(offset + 1);
+        }
+    }
+
+    let mut block_starts = root
+        .children()
+        .map(|node| node.data().sourcepos.start.line)
+        .collect::<Vec<_>>();
+    block_starts.dedup();
+
+    for (index, start_line) in block_starts.iter().copied().enumerate() {
+        let from = *line_starts.get(start_line.saturating_sub(1))?;
+        let to = block_starts
+            .get(index + 1)
+            .and_then(|line| line_starts.get(line.saturating_sub(1)))
+            .copied()
+            .unwrap_or(md.len());
+
+        if markdown_has_unresolved_reference_link(&md[from..to], options) {
+            return Some(start_line);
+        }
+    }
+
+    None
+}
+
+fn markdown_has_unresolved_reference_link(md: &str, options: &Options<'static>) -> bool {
+    let unresolved_reference_links = Arc::new(AtomicUsize::new(0));
+    let callback_count = Arc::clone(&unresolved_reference_links);
+    let mut options = options.clone();
+
+    options.parse.broken_link_callback = Some(Arc::new(
+        move |_reference: comrak::options::BrokenLinkReference<'_>| {
+            callback_count.fetch_add(1, Ordering::Relaxed);
+            None
+        },
+    ));
+
+    let arena = Arena::new();
+    let root = comrak::parse_document(&arena, md, &options);
+    let task_items = root
+        .descendants()
+        .filter(|node| matches!(&node.data().value, NodeValue::TaskItem(_)))
+        .count();
+
+    unresolved_reference_links.load(Ordering::Relaxed) > task_items
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/test/mdex_native/comrak_test.exs
+++ b/test/mdex_native/comrak_test.exs
@@ -44,6 +44,53 @@ defmodule MDExNative.ComrakTest do
     assert html =~ ~s(<input type="checkbox" checked="" disabled="" /> done)
   end
 
+  test "reports unresolved reference links from the parser" do
+    assert {_document, true, 1} =
+             MDExNative.Native.parse_document_with_metadata("Read [the docs].", %{})
+
+    assert {_document, false, 1} =
+             MDExNative.Native.parse_document_with_metadata(
+               """
+               Read [the docs].
+
+               Another paragraph.
+
+               [the docs]: https://example.com
+               """,
+               %{}
+             )
+
+    assert {_document, false, nil} =
+             MDExNative.Native.parse_document_with_metadata(
+               "- [x] done",
+               %{extension: %{tasklist: true}}
+             )
+
+    assert {_document, false, nil} =
+             MDExNative.Native.parse_document_with_metadata(
+               "- [ ] pending",
+               %{extension: %{tasklist: true}}
+             )
+
+    assert {_document, true, 3} =
+             MDExNative.Native.parse_document_with_metadata(
+               "- [x] done\n\nRegular [x].",
+               %{extension: %{tasklist: true}}
+             )
+
+    assert {_document, true, 3} =
+             MDExNative.Native.parse_document_with_metadata(
+               "- [ ] pending\n\nRegular [x].",
+               %{extension: %{tasklist: true}}
+             )
+
+    assert {_document, false, nil} =
+             MDExNative.Native.parse_document_with_metadata(
+               "[the docs](https://example.com)",
+               %{}
+             )
+  end
+
   test "renders heading anchors using Comrak 0.54 markup" do
     assert MDExNative.Comrak.markdown_to_html("# Hello",
              extension: [header_id_prefix: "user-content-"]

--- a/test/mdex_native/comrak_test.exs
+++ b/test/mdex_native/comrak_test.exs
@@ -60,6 +60,16 @@ defmodule MDExNative.ComrakTest do
                %{}
              )
 
+    assert {_document, false, 1} =
+             MDExNative.Native.parse_document_with_metadata(
+               """
+               Read [the docs].
+
+               [the docs]: https://example.com
+               """,
+               %{}
+             )
+
     assert {_document, false, nil} =
              MDExNative.Native.parse_document_with_metadata(
                "- [x] done",


### PR DESCRIPTION
## Summary

- add an internal parser metadata NIF under the hidden `MDExNative.Native` module
- return the parsed document with parser-owned reference-link metadata
- report unresolved reference links and the first top-level block that depends on a later definition
- avoid treating task-list markers as unresolved reference links
- keep the implementation out of the public `MDExNative.Comrak` API and docs
- test the internal contract used by MDEx

MDEx uses this metadata to stream complete blocks without duplicating Markdown recognition in Elixir.

## Related PR

- MDEx Stream API consumer: [leandrocp/mdex#397](https://github.com/leandrocp/mdex/pull/397)

## Release order

This feature is intended for mdex_native 0.2.9. It must merge before the 0.2.9 release PR is regenerated and released. MDEx can use this branch while both PRs are under review.

## Validation

- `MDEX_NATIVE_BUILD=1 MIX_ENV=test mix test`: 54 passed (20 doctests and 34 tests), plus 4 default-feature Rust tests
- `cargo test --all-features`: 37 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `mix compile --force --warnings-as-errors`
- `mix credo`
- `mix format --check-formatted`
- `cargo fmt --check`
- documentation build
- `git diff --check`
