### PR TITLE
ci: enforce Rust and Elixir complexity limits

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -5,6 +5,11 @@
       files: %{
         included: ["config/", "lib/", "test/", "examples/", "integration_test/"],
         excluded: ["integration_test/_build/", "integration_test/tmp/"]
+      },
+      checks: %{
+        extra: [
+          {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 9}
+        ]
       }
     }
   ]

--- a/native/mdex_native_nif/Cargo.toml
+++ b/native/mdex_native_nif/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Leandro Pereira"]
 edition = "2021"
 rust-version = "1.91"
 
+[lints.clippy]
+cognitive_complexity = "deny"
+
 [lib]
 name = "mdex_native_nif"
 path = "src/lib.rs"

--- a/native/mdex_native_nif/clippy.toml
+++ b/native/mdex_native_nif/clippy.toml
@@ -1,0 +1,1 @@
+cognitive-complexity-threshold = 25

--- a/native/mdex_native_nif/src/types/options.rs
+++ b/native/mdex_native_nif/src/types/options.rs
@@ -128,7 +128,13 @@ impl<'a> Decoder<'a> for ExExtensionOptions {
 
 #[allow(deprecated)]
 impl ExExtensionOptions {
-    pub fn apply(self, extension: &mut Extension<'static>) {
+    pub fn apply(mut self, extension: &mut Extension<'static>) {
+        self.apply_common_options(extension);
+        self.apply_additional_options(extension);
+        self.apply_rewriters_and_attributes(extension);
+    }
+
+    fn apply_common_options(&mut self, extension: &mut Extension<'static>) {
         if let Some(value) = self.strikethrough {
             extension.strikethrough = value;
         }
@@ -147,8 +153,8 @@ impl ExExtensionOptions {
         if let Some(value) = self.superscript {
             extension.superscript = value;
         }
-        if self.header_id_prefix.is_some() {
-            extension.header_id_prefix = self.header_id_prefix;
+        if let Some(value) = self.header_id_prefix.take() {
+            extension.header_id_prefix = Some(value);
         }
         if let Some(value) = self.header_id_prefix_in_href {
             extension.header_id_prefix_in_href = value;
@@ -159,11 +165,14 @@ impl ExExtensionOptions {
         if let Some(value) = self.inline_footnotes {
             extension.inline_footnotes = value;
         }
+    }
+
+    fn apply_additional_options(&mut self, extension: &mut Extension<'static>) {
         if let Some(value) = self.description_lists {
             extension.description_lists = value;
         }
-        if self.front_matter_delimiter.is_some() {
-            extension.front_matter_delimiter = self.front_matter_delimiter;
+        if let Some(value) = self.front_matter_delimiter.take() {
+            extension.front_matter_delimiter = Some(value);
         }
         if let Some(value) = self.multiline_block_quotes {
             extension.multiline_block_quotes = value;
@@ -210,11 +219,14 @@ impl ExExtensionOptions {
         if let Some(value) = self.insert {
             extension.insert = value;
         }
-        if let Some(rewrite) = self.image_url_rewriter {
+    }
+
+    fn apply_rewriters_and_attributes(&mut self, extension: &mut Extension<'static>) {
+        if let Some(rewrite) = self.image_url_rewriter.take() {
             extension.image_url_rewriter =
                 Some(Arc::new(move |url: &str| rewrite.replace("{@url}", url)));
         }
-        if let Some(rewrite) = self.link_url_rewriter {
+        if let Some(rewrite) = self.link_url_rewriter.take() {
             extension.link_url_rewriter =
                 Some(Arc::new(move |url: &str| rewrite.replace("{@url}", url)));
         }


### PR DESCRIPTION
## Summary

- enforce Clippy cognitive complexity with a maximum of 25
- enforce Credo cyclomatic complexity with a maximum of 9
- split ExExtensionOptions.apply into focused helpers to fix the existing 37/25 Rust violation

## Validation

- cargo +nightly clippy --all-targets --all-features --manifest-path native/mdex_native_nif/Cargo.toml -- -D warnings
- cargo +1.91.1 check --manifest-path native/mdex_native_nif/Cargo.toml
- cargo test --all-features --manifest-path native/mdex_native_nif/Cargo.toml
- env MDEX_NATIVE_BUILD=1 mix test
- mix credo
- mix format --check-formatted
- cargo fmt --all --manifest-path native/mdex_native_nif/Cargo.toml -- --check
- git diff --check