### PR TITLE
ci: enforce cyclomatic complexity ceiling with strict linting

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,14 +1,30 @@
+# Credo runs in strict mode, so `mix credo` locally reports exactly what CI
+# reports. The settings below are the ones this repository pins on purpose;
+# everything else is Credo's own default.
 %{
   configs: [
     %{
       name: "default",
+      strict: true,
       files: %{
-        included: ["config/", "lib/", "test/", "examples/", "integration_test/"],
-        excluded: ["integration_test/_build/", "integration_test/tmp/"]
+        included: ["lib/", "src/", "test/", "config/", "examples/", "integration_test/", "mix.exs"],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/", ~r"/integration_test/tmp/"]
       },
       checks: %{
         extra: [
-          {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 9}
+          # Classic McCabe cyclomatic complexity, at the ceiling shared by every
+          # project in this family, in Elixir and in JavaScript alike.
+          {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 9},
+          # Credo's strict default, or `line_length` from .formatter.exs where
+          # that is larger, so the formatter and the linter cannot disagree about
+          # a line the formatter itself produced.
+          {Credo.Check.Readability.MaxLineLength, max_length: 120}
+        ],
+        disabled: [
+          # TODO and FIXME notes are tracked in the issue tracker. Failing a
+          # build on one only encourages deleting the note.
+          {Credo.Check.Design.TagTODO, []},
+          {Credo.Check.Design.TagFIXME, []}
         ]
       }
     }

--- a/.credo.exs
+++ b/.credo.exs
@@ -7,7 +7,15 @@
       name: "default",
       strict: true,
       files: %{
-        included: ["lib/", "src/", "test/", "config/", "examples/", "integration_test/", "mix.exs"],
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "config/",
+          "examples/",
+          "integration_test/",
+          "mix.exs"
+        ],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/", ~r"/integration_test/tmp/"]
       },
       checks: %{

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,6 +28,7 @@ jobs:
       pairs: '[{"name":"OTP 29, Elixir main", "elixir":"main-otp-29", "otp":"maint-29"}]'
       env_vars: '{"MDEX_NATIVE_BUILD": "1"}'
       credo: true
+      credo_args: '--strict'
 
   e2e:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') }}

--- a/native/mdex_native_nif/clippy.toml
+++ b/native/mdex_native_nif/clippy.toml
@@ -1,1 +1,7 @@
-cognitive-complexity-threshold = 25
+# Complexity ceiling for this crate, denied in Cargo.toml's [lints.clippy].
+#
+# Cognitive rather than cyclomatic complexity: `?` makes every fallible call a
+# cyclomatic branch, which scores a flat 36-field decoder the same as a deeply
+# nested function. 10 is the Rust counterpart of the ceiling of 9 that Credo
+# enforces on the Elixir here and oxlint enforces on the JavaScript elsewhere.
+cognitive-complexity-threshold = 10

--- a/native/mdex_native_nif/src/lumis_adapter.rs
+++ b/native/mdex_native_nif/src/lumis_adapter.rs
@@ -355,6 +355,54 @@ impl LumisAdapter {
             .and_then(|info| Self::parse_custom_attributes(info.as_ref()))
     }
 
+    /// The language the decorator was told to use, or the best guess from the
+    /// info string and the source itself.
+    fn resolve_language(&self, lang: Option<&str>, source: &str) -> Language {
+        if let Some(stored_lang) = *self.stored_lang.lock() {
+            stored_lang
+        } else {
+            Language::guess(Some(lang.unwrap_or("plaintext")), source)
+        }
+    }
+
+    /// The `class` and `style` attributes for one output line: `l-line` on its
+    /// own, plus whatever `highlight_lines` asked for on the lines it covers.
+    fn line_attrs(
+        &self,
+        highlight_config: Option<&(HashSet<usize>, Option<String>, Option<String>)>,
+        line_number: usize,
+    ) -> (String, String) {
+        let mut class_name = String::from("l-line");
+        let mut style_attr = String::new();
+
+        let Some((lines, style, class)) = highlight_config else {
+            return (class_name, style_attr);
+        };
+        if !lines.contains(&line_number) {
+            return (class_name, style_attr);
+        }
+
+        if let Some(class) = class {
+            class_name.push(' ');
+            class_name.push_str(&self.escape_unless_unsafe(class));
+        }
+        if let Some(style) = style {
+            style_attr = format!(" style=\"{}\"", self.escape_unless_unsafe(style));
+        }
+
+        (class_name, style_attr)
+    }
+
+    /// Author-supplied attribute values are escaped unless the document opted
+    /// into raw HTML, which is the same trade `render.unsafe` makes elsewhere.
+    fn escape_unless_unsafe(&self, value: &str) -> String {
+        if self.render_unsafe {
+            value.to_string()
+        } else {
+            v_htmlescape::escape_fmt(value).to_string()
+        }
+    }
+
     fn span_with_attrs(text: &str, attrs: String) -> String {
         let escaped = html::escape(text);
 
@@ -450,15 +498,7 @@ impl SyntaxHighlighterAdapter for LumisAdapter {
         lang: Option<&str>,
         source: &str,
     ) -> std::fmt::Result {
-        let stored_lang = *self.stored_lang.lock();
-
-        let language = if let Some(stored_lang) = stored_lang {
-            stored_lang
-        } else if let Some(lang_str) = lang {
-            Language::guess(Some(lang_str), source)
-        } else {
-            Language::guess(Some("plaintext"), source)
-        };
+        let language = self.resolve_language(lang, source);
         let is_plaintext = language == Language::PlainText;
 
         let theme = self
@@ -543,28 +583,7 @@ impl SyntaxHighlighterAdapter for LumisAdapter {
 
         for (i, line) in html_output.lines().enumerate() {
             let line_number = i + 1;
-            let mut class_name = String::from("l-line");
-            let mut style_attr = String::new();
-
-            if let Some((ref lines, ref style, ref class)) = highlight_config {
-                if lines.contains(&line_number) {
-                    if let Some(ref c) = class {
-                        class_name.push(' ');
-                        if self.render_unsafe {
-                            class_name.push_str(c);
-                        } else {
-                            class_name.push_str(&v_htmlescape::escape_fmt(c).to_string());
-                        }
-                    }
-                    if let Some(ref s) = style {
-                        if self.render_unsafe {
-                            style_attr = format!(" style=\"{}\"", s);
-                        } else {
-                            style_attr = format!(" style=\"{}\"", v_htmlescape::escape_fmt(s));
-                        }
-                    }
-                }
-            }
+            let (class_name, style_attr) = self.line_attrs(highlight_config.as_ref(), line_number);
 
             write!(
                 output,

--- a/native/mdex_native_nif/src/types/options.rs
+++ b/native/mdex_native_nif/src/types/options.rs
@@ -8,6 +8,23 @@ use rustler::{Decoder, NifResult, NifUnitEnum, Term};
 pub use sanitize::*;
 use std::sync::Arc;
 
+/// Overwrites `target` when Elixir sent a value for the field, and leaves it
+/// at its Comrak default when it did not. Every `apply` below is a list of
+/// these, so the rule lives in one place instead of once per field.
+fn overwrite<T>(target: &mut T, value: Option<T>) {
+    if let Some(value) = value {
+        *target = value;
+    }
+}
+
+/// Same rule for a field that is itself optional: `nil` from Elixir means
+/// "leave it alone", not "clear it".
+fn overwrite_optional<T>(target: &mut Option<T>, value: Option<T>) {
+    if value.is_some() {
+        *target = value;
+    }
+}
+
 fn is_atom(term: Term, name: &str) -> NifResult<bool> {
     Ok(Atom::decode(term).is_ok_and(|atom| {
         Atom::from_str(term.get_env(), name).is_ok_and(|expected| atom == expected)
@@ -135,90 +152,54 @@ impl ExExtensionOptions {
     }
 
     fn apply_common_options(&mut self, extension: &mut Extension<'static>) {
-        if let Some(value) = self.strikethrough {
-            extension.strikethrough = value;
-        }
-        if let Some(value) = self.tagfilter {
-            extension.tagfilter = value;
-        }
-        if let Some(value) = self.table {
-            extension.table = value;
-        }
-        if let Some(value) = self.autolink {
-            extension.autolink = value;
-        }
-        if let Some(value) = self.tasklist {
-            extension.tasklist = value;
-        }
-        if let Some(value) = self.superscript {
-            extension.superscript = value;
-        }
-        if let Some(value) = self.header_id_prefix.take() {
-            extension.header_id_prefix = Some(value);
-        }
-        if let Some(value) = self.header_id_prefix_in_href {
-            extension.header_id_prefix_in_href = value;
-        }
-        if let Some(value) = self.footnotes {
-            extension.footnotes = value;
-        }
-        if let Some(value) = self.inline_footnotes {
-            extension.inline_footnotes = value;
-        }
+        overwrite(&mut extension.strikethrough, self.strikethrough);
+        overwrite(&mut extension.tagfilter, self.tagfilter);
+        overwrite(&mut extension.table, self.table);
+        overwrite(&mut extension.autolink, self.autolink);
+        overwrite(&mut extension.tasklist, self.tasklist);
+        overwrite(&mut extension.superscript, self.superscript);
+        overwrite_optional(
+            &mut extension.header_id_prefix,
+            self.header_id_prefix.take(),
+        );
+        overwrite(
+            &mut extension.header_id_prefix_in_href,
+            self.header_id_prefix_in_href,
+        );
+        overwrite(&mut extension.footnotes, self.footnotes);
+        overwrite(&mut extension.inline_footnotes, self.inline_footnotes);
     }
 
     fn apply_additional_options(&mut self, extension: &mut Extension<'static>) {
-        if let Some(value) = self.description_lists {
-            extension.description_lists = value;
-        }
-        if let Some(value) = self.front_matter_delimiter.take() {
-            extension.front_matter_delimiter = Some(value);
-        }
-        if let Some(value) = self.multiline_block_quotes {
-            extension.multiline_block_quotes = value;
-        }
-        if let Some(value) = self.alerts {
-            extension.alerts = value;
-        }
-        if let Some(value) = self.math_dollars {
-            extension.math_dollars = value;
-        }
-        if let Some(value) = self.math_latex {
-            extension.math_latex = value;
-        }
-        if let Some(value) = self.math_code {
-            extension.math_code = value;
-        }
-        if let Some(value) = self.shortcodes {
-            extension.shortcodes = value;
-        }
-        if let Some(value) = self.wikilinks_title_after_pipe {
-            extension.wikilinks_title_after_pipe = value;
-        }
-        if let Some(value) = self.wikilinks_title_before_pipe {
-            extension.wikilinks_title_before_pipe = value;
-        }
-        if let Some(value) = self.underline {
-            extension.underline = value;
-        }
-        if let Some(value) = self.subscript {
-            extension.subscript = value;
-        }
-        if let Some(value) = self.spoiler {
-            extension.spoiler = value;
-        }
-        if let Some(value) = self.greentext {
-            extension.greentext = value;
-        }
-        if let Some(value) = self.subtext {
-            extension.subtext = value;
-        }
-        if let Some(value) = self.highlight {
-            extension.highlight = value;
-        }
-        if let Some(value) = self.insert {
-            extension.insert = value;
-        }
+        overwrite(&mut extension.description_lists, self.description_lists);
+        overwrite_optional(
+            &mut extension.front_matter_delimiter,
+            self.front_matter_delimiter.take(),
+        );
+        overwrite(
+            &mut extension.multiline_block_quotes,
+            self.multiline_block_quotes,
+        );
+        overwrite(&mut extension.alerts, self.alerts);
+        overwrite(&mut extension.math_dollars, self.math_dollars);
+        overwrite(&mut extension.math_latex, self.math_latex);
+        overwrite(&mut extension.math_code, self.math_code);
+        overwrite(&mut extension.shortcodes, self.shortcodes);
+        overwrite(
+            &mut extension.wikilinks_title_after_pipe,
+            self.wikilinks_title_after_pipe,
+        );
+        overwrite(
+            &mut extension.wikilinks_title_before_pipe,
+            self.wikilinks_title_before_pipe,
+        );
+        overwrite(&mut extension.underline, self.underline);
+        overwrite(&mut extension.subscript, self.subscript);
+        overwrite(&mut extension.spoiler, self.spoiler);
+        overwrite(&mut extension.greentext, self.greentext);
+        overwrite(&mut extension.subtext, self.subtext);
+        overwrite(&mut extension.highlight, self.highlight);
+        overwrite(&mut extension.insert, self.insert);
     }
 
     fn apply_rewriters_and_attributes(&mut self, extension: &mut Extension<'static>) {
@@ -230,27 +211,22 @@ impl ExExtensionOptions {
             extension.link_url_rewriter =
                 Some(Arc::new(move |url: &str| rewrite.replace("{@url}", url)));
         }
-        if let Some(value) = self.cjk_friendly_emphasis {
-            extension.cjk_friendly_emphasis = value;
-        }
-        if let Some(value) = self.phoenix_heex {
-            extension.phoenix_heex = value;
-        }
-        if let Some(value) = self.block_directive {
-            extension.block_directive = value;
-        }
-        if let Some(value) = self.header_attributes {
-            extension.header_attributes = value;
-        }
-        if let Some(value) = self.fenced_code_attributes {
-            extension.fenced_code_attributes = value;
-        }
-        if let Some(value) = self.inline_code_attributes {
-            extension.inline_code_attributes = value;
-        }
-        if let Some(value) = self.link_attributes {
-            extension.link_attributes = value;
-        }
+        overwrite(
+            &mut extension.cjk_friendly_emphasis,
+            self.cjk_friendly_emphasis,
+        );
+        overwrite(&mut extension.phoenix_heex, self.phoenix_heex);
+        overwrite(&mut extension.block_directive, self.block_directive);
+        overwrite(&mut extension.header_attributes, self.header_attributes);
+        overwrite(
+            &mut extension.fenced_code_attributes,
+            self.fenced_code_attributes,
+        );
+        overwrite(
+            &mut extension.inline_code_attributes,
+            self.inline_code_attributes,
+        );
+        overwrite(&mut extension.link_attributes, self.link_attributes);
     }
 }
 
@@ -285,33 +261,21 @@ impl<'a> Decoder<'a> for ExParseOptions {
 
 impl ExParseOptions {
     pub fn apply(self, parse: &mut Parse<'static>) {
-        if let Some(value) = self.smart {
-            parse.smart = value;
-        }
-        if self.default_info_string.is_some() {
-            parse.default_info_string = self.default_info_string;
-        }
-        if let Some(value) = self.relaxed_tasklist_matching {
-            parse.relaxed_tasklist_matching = value;
-        }
-        if let Some(value) = self.relaxed_autolinks {
-            parse.relaxed_autolinks = value;
-        }
-        if let Some(value) = self.ignore_setext {
-            parse.ignore_setext = value;
-        }
-        if let Some(value) = self.tasklist_in_table {
-            parse.tasklist_in_table = value;
-        }
-        if let Some(value) = self.leave_footnote_definitions {
-            parse.leave_footnote_definitions = value;
-        }
-        if let Some(value) = self.escaped_char_spans {
-            parse.escaped_char_spans = value;
-        }
-        if let Some(value) = self.sourcepos_chars {
-            parse.sourcepos_chars = value;
-        }
+        overwrite(&mut parse.smart, self.smart);
+        overwrite_optional(&mut parse.default_info_string, self.default_info_string);
+        overwrite(
+            &mut parse.relaxed_tasklist_matching,
+            self.relaxed_tasklist_matching,
+        );
+        overwrite(&mut parse.relaxed_autolinks, self.relaxed_autolinks);
+        overwrite(&mut parse.ignore_setext, self.ignore_setext);
+        overwrite(&mut parse.tasklist_in_table, self.tasklist_in_table);
+        overwrite(
+            &mut parse.leave_footnote_definitions,
+            self.leave_footnote_definitions,
+        );
+        overwrite(&mut parse.escaped_char_spans, self.escaped_char_spans);
+        overwrite(&mut parse.sourcepos_chars, self.sourcepos_chars);
     }
 }
 
@@ -401,60 +365,33 @@ impl<'a> Decoder<'a> for ExRenderOptions {
 
 impl ExRenderOptions {
     pub fn apply(self, render: &mut Render) {
-        if let Some(value) = self.hardbreaks {
-            render.hardbreaks = value;
-        }
-        if let Some(value) = self.github_pre_lang {
-            render.github_pre_lang = value;
-        }
-        if let Some(value) = self.full_info_string {
-            render.full_info_string = value;
-        }
-        if let Some(value) = self.width {
-            render.width = value;
-        }
-        if let Some(value) = self.r#unsafe {
-            render.r#unsafe = value;
-        }
-        if let Some(value) = self.escape {
-            render.escape = value;
-        }
-        if let Some(value) = self.list_style {
-            render.list_style = ListStyleType::from(value);
-        }
-        if let Some(value) = self.sourcepos {
-            render.sourcepos = value;
-        }
-        if let Some(value) = self.escaped_char_spans {
-            render.escaped_char_spans = value;
-        }
-        if let Some(value) = self.ignore_empty_links {
-            render.ignore_empty_links = value;
-        }
-        if let Some(value) = self.gfm_quirks {
-            render.gfm_quirks = value;
-        }
-        if let Some(value) = self.prefer_fenced {
-            render.prefer_fenced = value;
-        }
-        if let Some(value) = self.figure_with_caption {
-            render.figure_with_caption = value;
-        }
-        if let Some(value) = self.tasklist_classes {
-            render.tasklist_classes = value;
-        }
-        if let Some(value) = self.ol_width {
-            render.ol_width = value;
-        }
-        if let Some(value) = self.experimental_minimize_commonmark {
-            render.experimental_minimize_commonmark = value;
-        }
-        if let Some(value) = self.compact_html {
-            render.compact_html = value;
-        }
-        if let Some(value) = self.alert_style {
-            render.alert_style = value.into();
-        }
+        overwrite(&mut render.hardbreaks, self.hardbreaks);
+        overwrite(&mut render.github_pre_lang, self.github_pre_lang);
+        overwrite(&mut render.full_info_string, self.full_info_string);
+        overwrite(&mut render.width, self.width);
+        overwrite(&mut render.r#unsafe, self.r#unsafe);
+        overwrite(&mut render.escape, self.escape);
+        overwrite(
+            &mut render.list_style,
+            self.list_style.map(ListStyleType::from),
+        );
+        overwrite(&mut render.sourcepos, self.sourcepos);
+        overwrite(&mut render.escaped_char_spans, self.escaped_char_spans);
+        overwrite(&mut render.ignore_empty_links, self.ignore_empty_links);
+        overwrite(&mut render.gfm_quirks, self.gfm_quirks);
+        overwrite(&mut render.prefer_fenced, self.prefer_fenced);
+        overwrite(&mut render.figure_with_caption, self.figure_with_caption);
+        overwrite(&mut render.tasklist_classes, self.tasklist_classes);
+        overwrite(&mut render.ol_width, self.ol_width);
+        overwrite(
+            &mut render.experimental_minimize_commonmark,
+            self.experimental_minimize_commonmark,
+        );
+        overwrite(&mut render.compact_html, self.compact_html);
+        overwrite(
+            &mut render.alert_style,
+            self.alert_style.map(AlertStyleType::from),
+        );
     }
 }
 

--- a/test/mdex_native/comrak_test.exs
+++ b/test/mdex_native/comrak_test.exs
@@ -48,9 +48,9 @@ defmodule MDExNative.ComrakTest do
     assert MDExNative.Comrak.markdown_to_html("# Hello",
              extension: [header_id_prefix: "user-content-"]
            ) ==
-             "<h1 id=\"user-content-hello\">Hello" <>
-               "<a href=\"#hello\" aria-label=\"Link to heading 'Hello'\" " <>
-               "data-heading-content=\"Hello\" class=\"anchor\"></a></h1>\n"
+             ~s(<h1 id="user-content-hello">Hello) <>
+               ~s(<a href="#hello" aria-label="Link to heading 'Hello'" ) <>
+               ~s(data-heading-content="Hello" class="anchor"></a></h1>\n)
   end
 
   test "renders LaTeX-delimited math when math_latex is enabled" do


### PR DESCRIPTION
Adds a cyclomatic complexity ceiling and turns the linter up to strict, so both
run on every push and pull request. Part of applying one complexity standard
across the projects in this family.

## What this enforces

- `.credo.exs` pins `Credo.Check.Refactor.CyclomaticComplexity` at **max 9** —
  classic McCabe, the same metric and ceiling that oxlint's `eslint/complexity`
  enforces on the JavaScript in the sibling repositories.
- `strict: true` lives in the config rather than only in the CI invocation, so a
  local `mix credo` reports exactly what CI reports.
- `Credo.Check.Readability.MaxLineLength` is set to Credo's strict default of
  120, or to `.formatter.exs`'s `line_length` where that is larger, so the
  formatter and the linter cannot disagree about a line the formatter produced.
- `Credo.Check.Design.TagTODO` / `TagFIXME` are off. Those notes belong in the
  issue tracker; failing a build on one only encourages deleting the note.

## CI

The `lint` job now passes `credo: true` and `credo_args: '--strict'` to the
shared `elixir-lint.yml` workflow.

`credo` already ran here; it now runs with `--strict`, and the config keeps the
extra source directories this repository checks.

The Rust NIF already denied `clippy::cognitive_complexity`, at a threshold of
**25**. That is lowered to **10**, the Rust counterpart of the Elixir ceiling of
9. Cognitive rather than cyclomatic complexity for Rust: `?` makes every
fallible call a cyclomatic branch, which scores this crate's flat 36-field
decoder the same as a deeply nested function.

## Code changes

Four functions were over the new threshold.

- `ExExtensionOptions::apply_common_options`, `apply_additional_options`,
  `apply_rewriters_and_attributes`, `ExParseOptions::apply` and
  `ExRenderOptions::apply` were each a long list of
  `if let Some(value) = self.field { target.field = value; }`. The
  "leave it at the Comrak default unless Elixir sent something" rule now lives
  in two small helpers, `overwrite` and `overwrite_optional`, and each `apply`
  is a flat list of calls. This removes about 130 lines.
- `LumisAdapter::write_highlighted` did three things at once. Picking the
  language moved to `resolve_language`, and the four-deep block that built each
  line's `class` and `style` moved to `line_attrs` plus `escape_unless_unsafe`,
  which also puts the `render.unsafe` escaping decision in one place instead of
  two.

Verified with `cargo clippy --all-targets --all-features` (clean at the new
threshold), `cargo test` (37 passed), `mix credo --strict` (clean) and
`MDEX_NATIVE_BUILD=1 mix test` (53 passed).
